### PR TITLE
fixs error install target pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: $(PROG)
 $(PROG): $(OBJS)
 	$(CC) $(OBJS) $(LDPATH) $(LIBS) -o $@
 
-$(OBJS): *.o: *.c
+$(OBJS): *.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 install: all


### PR DESCRIPTION
When you run make install it drops the following message:

> Makefile:27: *** target pattern contains no '%'.  Stop.

I fixed this with this patch (pull request)